### PR TITLE
Compatible with GNOME Shell 3.14.4

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,7 @@
   "description": "Buckets of emoji for your messaging pleasure.",
   "settings-schema": "org.gnome.shell.extensions.emoji-buckets",
   "shell-version": [
+    "3.14.4",
     "3.18",
     "3.20",
     "3.22"


### PR DESCRIPTION
Seems to work perfectly fine with the build in Debian Jessie, anyway.